### PR TITLE
test: poll-race-mshot: Fix incorrect posix_memalign

### DIFF
--- a/test/poll-race-mshot.c
+++ b/test/poll-race-mshot.c
@@ -158,7 +158,7 @@ static int test_mshot(struct io_uring *ring, struct data *d)
 
 	d->fd = fd[1];
 
-	if (posix_memalign((void *) &buf, 16384, BUF_SIZE * NREQS))
+	if (posix_memalign((void **) &buf, 16384, BUF_SIZE * NREQS))
 		return T_EXIT_FAIL;
 
 	br = io_uring_setup_buf_ring(ring, NREQS, 1, 0, &ret);


### PR DESCRIPTION
Pass &buf (void **) instead of (void *) &buf to posix_memalign to avoid possible undefined behavior.